### PR TITLE
Implement message catch-up via Last-Event-ID

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -144,12 +144,12 @@ impl Script {
 
     pub async fn catchup(
         &self,
-        sub_req: SubReq,
-        last_event_id: String,
+        sub_req: &SubReq,
+        last_event_id: &str,
     ) -> anyhow::Result<Option<Vec<Msg>>> {
         if let Ok(func) = self.lua.named_registry_value::<mlua::Function>("catchup") {
             return Ok(func
-                .call_async::<Option<Vec<Msg>>>((sub_req, last_event_id))
+                .call_async::<Option<Vec<Msg>>>((sub_req.clone(), last_event_id))
                 .await?);
         }
 


### PR DESCRIPTION
Message catch-up is now implemented by defining a `catchup(sub, last_event_id)` Lua function that is expected to return an array table of SSE messages to deliver to the client immediately upon new subscription.


```lua
function catchup(sub, last_event_id)
  local msgs = {}

  -- For instance, "catch-up" subscriber with the 10 most recent messages
  for i=1,10 do
    table.insert(msgs, {
      id = "some-id-" .. i,
      event = "some-event",
      data = "some data"
    })
  end

  return msgs
end
```