### PR TITLE
Always call the `catchup(sub, last_event_id)` function

### DIFF
--- a/src/req.rs
+++ b/src/req.rs
@@ -201,25 +201,16 @@ impl mlua::IntoLua for PubReq {
 #[derive(Debug, Clone)]
 pub struct SubReq {
     req: Req,
-    last_event_id: Option<String>,
     meta: Option<mlua::Table>,
 }
 
 impl SubReq {
-    pub fn new(req: Req, last_event_id: Option<String>) -> Self {
-        Self {
-            req,
-            last_event_id,
-            meta: None,
-        }
+    pub fn new(req: Req) -> Self {
+        Self { req, meta: None }
     }
 
     pub fn req(&self) -> &Req {
         &self.req
-    }
-
-    pub fn last_event_id(&self) -> Option<&str> {
-        self.last_event_id.as_deref()
     }
 
     pub fn meta(&self) -> Option<&mlua::Table> {
@@ -234,12 +225,8 @@ impl mlua::FromLua for SubReq {
                 let req = tbl.get("req")?;
                 tbl.set("req", mlua::Value::Nil)?;
 
-                let last_event_id = tbl.get("last_event_id")?;
-                tbl.set("last_event_id", mlua::Value::Nil)?;
-
                 Ok(Self {
                     req,
-                    last_event_id,
                     meta: Some(tbl.to_owned()),
                 })
             }
@@ -258,9 +245,7 @@ impl mlua::IntoLua for SubReq {
             Some(tbl) => tbl,
             None => lua.create_table()?,
         };
-
         tbl.set("req", self.req)?;
-        tbl.set("last_event_id", self.last_event_id)?;
 
         lua.to_value(&tbl)
     }

--- a/src/script.rs
+++ b/src/script.rs
@@ -145,7 +145,7 @@ impl Script {
     pub async fn catchup(
         &self,
         sub_req: &SubReq,
-        last_event_id: &str,
+        last_event_id: Option<String>,
     ) -> anyhow::Result<Option<Vec<Msg>>> {
         if let Ok(func) = self.lua.named_registry_value::<mlua::Function>("catchup") {
             return Ok(func


### PR DESCRIPTION
`last_event_id` might be `nil` if the subscriber did not send it in the request.