### PR TITLE
Add `base64` package to Lua API

### DIFF
--- a/BUILTINS.md
+++ b/BUILTINS.md
@@ -7,11 +7,11 @@ The Tiny SSE server comes with several built-in packages.
 - [`uuid` - Generate UUIDs](#uuid)
 - [`json` - Encode and decode JSON](#json)
   - [JSON utility functions](#json-utility-functions)
+- [`base64` - Encode and decode base64](#base64)
 - [`url` - Parse and construct URLs](#url)
 - [`log` - Log messages to the server logger](#log)
 - [`http` - Make HTTP requests](#http)
 - [`sqlite` (EXPERIMENTAL) - Use an embedded database](#sqlite-experimental)
-
 
 ## `uuid`
 
@@ -103,6 +103,28 @@ json.pprint(tbl)
 --     3
 --   ]
 -- }
+```
+
+## `base64`
+
+Encode and decode base64
+
+```lua
+local base64 = require "base64"
+local s = "some binary string"
+local e = base64.encode(s)
+local d = base64.decode(e)
+assert(s == d)
+```
+
+`base64(val)` is an alias for `base64.encode(val)`
+
+The package also supports URL-safe base64 alphabets like:
+
+```lua
+local base64 = require("base64").urlsafe()
+
+-- rest of the API is the same
 ```
 
 ## `url`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "async-stream",
  "axum",
  "axum-extra",
+ "base64 0.22.1",
  "bytesize",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.93"
 async-stream = "0.3.6"
 axum = { version = "0.7.9", features = ["macros"] }
 axum-extra = { version = "0.9.6", features = ["typed-header", "typed-routing", "form", "query"] }
+base64 = "0.22.1"
 bytesize = { version = "1.3.2", features = ["serde"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.21", features = ["derive", "env", "wrap_help"] }

--- a/src/script.rs
+++ b/src/script.rs
@@ -63,6 +63,9 @@ impl Script {
         loaded
             .set("sqlite", userdata::Sqlite {})
             .expect("set userdata sqlite");
+        loaded
+            .set("base64", userdata::Base64 {})
+            .expect("set userdata base64");
 
         self.lua
             .load(include_str!("lua/global.lua"))

--- a/src/userdata/base64.rs
+++ b/src/userdata/base64.rs
@@ -1,0 +1,47 @@
+use base64::{
+    Engine as _,
+    engine::{
+        GeneralPurpose,
+        general_purpose::{STANDARD, URL_SAFE},
+    },
+};
+
+pub struct Base64;
+
+impl mlua::UserData for Base64 {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_function("urlsafe", |_lua, ()| Ok(UrlSafe));
+        methods.add_function("encode", |lua, val: mlua::Value| encode(lua, STANDARD, val));
+        methods.add_function("decode", |lua, val: String| decode(lua, STANDARD, val));
+        methods.add_meta_method(mlua::MetaMethod::Call, |lua, _this, val: mlua::Value| {
+            encode(lua, STANDARD, val)
+        });
+    }
+}
+
+pub struct UrlSafe;
+
+impl mlua::UserData for UrlSafe {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_function("encode", |lua, val: mlua::Value| encode(lua, URL_SAFE, val));
+        methods.add_function("decode", |lua, val: String| decode(lua, URL_SAFE, val));
+        methods.add_meta_method(mlua::MetaMethod::Call, |lua, _this, val: mlua::Value| {
+            encode(lua, URL_SAFE, val)
+        });
+    }
+}
+
+fn encode(_lua: &mlua::Lua, engine: GeneralPurpose, val: mlua::Value) -> mlua::Result<String> {
+    if let mlua::Value::String(val) = val {
+        Ok(engine.encode(val.as_bytes()))
+    } else {
+        Err(mlua::Error::external("expected string"))
+    }
+}
+
+fn decode(lua: &mlua::Lua, engine: GeneralPurpose, val: String) -> mlua::Result<mlua::Value> {
+    match engine.decode(val.as_bytes()) {
+        Ok(val) => Ok(mlua::Value::String(lua.create_string(&val)?)),
+        Err(e) => Err(mlua::Error::external(e)),
+    }
+}

--- a/src/userdata/mod.rs
+++ b/src/userdata/mod.rs
@@ -1,3 +1,4 @@
+pub mod base64;
 pub mod http;
 pub mod json;
 pub mod log;
@@ -7,6 +8,7 @@ pub mod sqlite;
 pub mod url;
 pub mod uuid;
 
+pub use base64::Base64;
 pub use http::Http;
 pub use json::Json;
 pub use log::Log;


### PR DESCRIPTION
This package adds base64 encoding and decoding functionality to the Lua API

```lua
local base64 = require "base64"
local s = "some binary string"
local e = base64.encode(s)
local d = base64.decode(e)
assert(s == d)
```

`base64(val)` is an alias for `base64.encode(val)`

The package also supports URL-safe base64 alphabets like:

```lua
local base64 = require("base64").urlsafe()

-- rest of the API is the same
```