### PR TITLE
Add program and version banner to startup log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,10 @@ async fn try_main(cli: &Cli) -> anyhow::Result<()> {
 
     let listener = TcpListener::bind(&cli.listen).await?;
     let local_addr = listener.local_addr()?;
+    tracing::info!(
+        "Started {}",
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"))
+    );
     tracing::info!("Listening on {local_addr}");
 
     state.script.startup(cli).await?;


### PR DESCRIPTION
Logs the program and version info to the startup log at info level

```
INFO tinysse: Started tinysse/0.5.0
INFO tinysse: Listening on 127.0.0.1:1983
```