### PR TITLE
Add `fernet` package in the Lua API

### DIFF
--- a/BUILTINS.md
+++ b/BUILTINS.md
@@ -14,6 +14,7 @@ The Tiny SSE server comes with several built-in packages.
 - [`sqlite` (EXPERIMENTAL) - Use an embedded database](#sqlite-experimental)
 - [`sleep` Pause script execution](#sleep)
 - [`mutex` Lock concurrent operations](#mutex)
+- [`fernet` Easy, safe symmetric encryption](#fernet)
 
 ## `uuid`
 
@@ -360,3 +361,20 @@ end)
 ```
 
 **NOTE:** Beware of recursive locking (calling `lock()` again inside the `lock`'s critical section). The code will deadlock.
+
+## `fernet`
+
+Easy, safe symmetric encryption
+
+Fernet provides symmetric-authenticated-encryption with an API that makes misusing it difficult. It is based on a public specification and there are interoperable implementations in Rust, Python, Ruby, JavaScript, Go, and many others.
+
+```lua
+local fernet = require "fernet"
+
+local key = fernet.genkey() -- Store this somewhere safe
+local f = fernet(key)
+local secret = "my secret message"
+local encrypted = f:encrypt(secret)
+local decrypted = f:decrypt(encrypted)
+assert(secret == decrypted)
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +444,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -537,6 +576,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -608,6 +648,23 @@ name = "fastrand"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+
+[[package]]
+name = "fernet"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66b725fe9483b9ee72ccaec072b15eb8ad95a3ae63a8c798d5748883b72fd33"
+dependencies = [
+ "aes",
+ "base64 0.22.1",
+ "byteorder",
+ "cbc",
+ "getrandom",
+ "hmac",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "flate2"
@@ -816,6 +873,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1111,6 +1177,16 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1498,7 +1574,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1839,6 +1915,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2088,7 @@ dependencies = [
  "chrono",
  "clap",
  "derive_more",
+ "fernet",
  "futures",
  "http",
  "http-body-util",
@@ -2709,6 +2797,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bytesize = { version = "1.3.2", features = ["serde"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.21", features = ["derive", "env", "wrap_help"] }
 derive_more = { version = "1.0.0", features = ["full"] }
+fernet = { version = "0.2.2", default-features = false, features = ["rustcrypto"] }
 futures = "0.3.31"
 http = "1.2.0"
 http-body-util = "0.1.2"

--- a/src/script.rs
+++ b/src/script.rs
@@ -66,6 +66,9 @@ impl Script {
         loaded
             .set("base64", userdata::Base64 {})
             .expect("set userdata base64");
+        loaded
+            .set("fernet", userdata::Fernet {})
+            .expect("set userdata fernet");
 
         self.lua
             .load(include_str!("lua/global.lua"))

--- a/src/userdata/fernet.rs
+++ b/src/userdata/fernet.rs
@@ -1,0 +1,57 @@
+pub struct Fernet;
+
+impl mlua::UserData for Fernet {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_function("genkey", |_, ()| Ok(fernet::Fernet::generate_key()));
+        methods.add_meta_method(
+            mlua::MetaMethod::Call,
+            |_lua, _this, key: Option<String>| {
+                let key = key.unwrap_or_else(fernet::Fernet::generate_key);
+
+                Ok(InnerFernet {
+                    inner: match fernet::Fernet::new(&key) {
+                        Some(fernet) => fernet,
+                        None => {
+                            return Err(mlua::Error::external(
+                                "key must be 32-bytes, url-safe base64-encoded",
+                            ));
+                        }
+                    },
+                })
+            },
+        );
+    }
+}
+
+struct InnerFernet {
+    inner: fernet::Fernet,
+}
+
+impl mlua::UserData for InnerFernet {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("encrypt", |_lua, this, val: mlua::Value| {
+            if let mlua::Value::String(val) = val {
+                Ok(this.inner.encrypt(&val.as_bytes()))
+            } else {
+                Err(mlua::Error::FromLuaConversionError {
+                    from: val.type_name(),
+                    to: "string".to_owned(),
+                    message: Some("expected string".to_owned()),
+                })
+            }
+        });
+
+        methods.add_method("decrypt", |lua, this, (val, ttl): (String, Option<u64>)| {
+            let plain = if let Some(ttl) = ttl {
+                this.inner.decrypt_with_ttl(&val, ttl)
+            } else {
+                this.inner.decrypt(&val)
+            };
+
+            match plain {
+                Ok(plain) => Ok(Some(lua.create_string(&plain)?)),
+                Err(_) => Ok(None),
+            }
+        });
+    }
+}

--- a/src/userdata/mod.rs
+++ b/src/userdata/mod.rs
@@ -1,4 +1,5 @@
 pub mod base64;
+pub mod fernet;
 pub mod http;
 pub mod json;
 pub mod log;
@@ -9,6 +10,7 @@ pub mod url;
 pub mod uuid;
 
 pub use base64::Base64;
+pub use fernet::Fernet;
 pub use http::Http;
 pub use json::Json;
 pub use log::Log;


### PR DESCRIPTION
## `fernet`

Easy, safe symmetric encryption

Fernet provides symmetric-authenticated-encryption with an API that makes misusing it difficult. It is based on a public specification and there are interoperable implementations in Rust, Python, Ruby, JavaScript, Go, and many others.

```lua
local fernet = require "fernet"

local key = fernet.genkey() -- Store this somewhere safe
local f = fernet(key)
local secret = "my secret message"
local encrypted = f:encrypt(secret)
local decrypted = f:decrypt(encrypted)

assert(secret == decrypted)
```