### PR TITLE
Use tokio::time::sleep instead of interval for script ticks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,11 +74,6 @@ async fn try_main(cli: &Cli) -> anyhow::Result<()> {
     tokio::select! {
         _ = async {
             // Run the script tick loop
-            let mut interval = tokio::time::interval(cli.script_tick);
-
-            // The first tick is immediate
-            interval.tick().await;
-
             let mut count = 0;
 
             loop {
@@ -88,7 +83,7 @@ async fn try_main(cli: &Cli) -> anyhow::Result<()> {
                     tracing::error!("{e}");
                 }
 
-                interval.tick().await;
+                tokio::time::sleep(cli.script_tick).await;
             }
         } => {},
 


### PR DESCRIPTION
When the script tick function itself takes longer than the tick interval then subsequent interval ticks fire in rapid succession.  This is fixed by just use `tokio::time::sleep` for tick intervals.