### PR TITLE
Expose mlua null value for translating Lua nil to Sqlite NULL

### DIFF
--- a/src/userdata/sqlite.rs
+++ b/src/userdata/sqlite.rs
@@ -11,7 +11,7 @@ impl Sqlite {
     /// # Arguments
     ///
     /// * `path` - A reference to a path specifying the SQLite database file.
-    ///            The special value `:memory:` can be used to open an in-memory database.
+    ///   The special value `:memory:` can be used to open an in-memory database.
     ///
     /// # Returns
     ///
@@ -96,6 +96,10 @@ impl Connection {
 }
 
 impl mlua::UserData for Connection {
+    fn add_fields<F: mlua::UserDataFields<Self>>(fields: &mut F) {
+        fields.add_field_method_get("null", |lua, _this| Ok(lua.null()));
+    }
+
     /// Adds Lua methods for the `Connection` struct.
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
         /// Executes a SQL statement with parameters from Lua.


### PR DESCRIPTION
Lua `nil` values are impossible to represent as SQL `NULL`, this PR exposes mlua's `null` value which translates to sqlite `NULL` (similarly to `json.null` in the `json` package).

```lua
local db = require("sqlite").open(":memory:")
db:exec("insert into foo (name) values (?)", {db.null})

-- translates to
-- insert into foo (name) values (NULL)
```