### PR TITLE
Preparing v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.7.0 (2025-04-14)
+===================
+* New `template` package in the Lua API
+* Add formatted logging functions to the `log` package
+* Add `sqlite.null` to represent SQL `NULL` values in the Lua API
+* Use `tokio::time::sleep` instead of `interval` for script tick intervals
+
+
 0.6.0 (2025-03-28)
 ===================
 * New `fernet` package in the Lua API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "tinysse"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinysse"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
0.7.0 (2025-04-14)
===================
* New `template` package in the Lua API
* Add formatted logging functions to the `log` package
* Add `sqlite.null` to represent SQL `NULL` values in the Lua API
* Use `tokio::time::sleep` instead of `interval` for script tick intervals