### PR TITLE
Return multi-values from mutex locks

### DIFF
--- a/src/userdata/mutex.rs
+++ b/src/userdata/mutex.rs
@@ -20,7 +20,7 @@ impl mlua::UserData for InnerMutex {
             mlua::MetaMethod::Call,
             |_lua, this, func: mlua::Function| async move {
                 let _guard = this.inner.lock().await;
-                func.call_async::<Option<mlua::Value>>(()).await
+                func.call_async::<mlua::MultiValue>(()).await
             },
         );
     }


### PR DESCRIPTION
For instance:

```lua
local mutex = require "mutex"
local lock = mutex()

local res1, res2 = lock(function()
  -- do a thing with locked resource
  return 1, 2
end)
```

assert(res1 == 1)
assert(res2 ==2)