### PR TITLE
Optimize release builds with codegen-units=1 and lto=true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2.5.4", features = ["serde"] }
 uuid = { version = "1.16.0", features = ["serde", "v4", "v7"] }
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
This increases the release build time from 30s -> 60s, but reduces the final binary size 14MB -> 9MB

Closes: https://github.com/benwilber/tinysse/issues/17